### PR TITLE
Rename the package to mas_perception_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(mcr_perception_msgs)
+project(mas_perception_msgs)
 
 find_package(catkin REQUIRED
   COMPONENTS

--- a/action/DetectScene.action
+++ b/action/DetectScene.action
@@ -1,6 +1,6 @@
 # Empty Goal
 ---
 # Result
-mcr_perception_msgs/Plane[] planes      # planes containing detected objects
+mas_perception_msgs/Plane[] planes      # planes containing detected objects
 ---
 # Empty Feedback

--- a/msg/BlobList.msg
+++ b/msg/BlobList.msg
@@ -1,4 +1,4 @@
 Header header
 
 # Array of Blobs
-mcr_perception_msgs/Blob[] blobs
+mas_perception_msgs/Blob[] blobs

--- a/msg/BoundingBoxList.msg
+++ b/msg/BoundingBoxList.msg
@@ -1,2 +1,2 @@
 Header header
-mcr_perception_msgs/BoundingBox[] bounding_boxes
+mas_perception_msgs/BoundingBox[] bounding_boxes

--- a/msg/Object.msg
+++ b/msg/Object.msg
@@ -23,5 +23,5 @@ sensor_msgs/Image rgb_image
 sensor_msgs/PointCloud2 pointcloud
 
 # The bounding box of the object
-mcr_perception_msgs/BoundingBox bounding_box
+mas_perception_msgs/BoundingBox bounding_box
 

--- a/msg/ObjectList.msg
+++ b/msg/ObjectList.msg
@@ -1,2 +1,2 @@
 # A list of objects
-mcr_perception_msgs/Object[] objects
+mas_perception_msgs/Object[] objects

--- a/msg/Plane.msg
+++ b/msg/Plane.msg
@@ -14,7 +14,7 @@ geometry_msgs/Point32[] convex_hull
 geometry_msgs/Point32 plane_point
 
 # Range of x, y coordinates
-mcr_perception_msgs/BoundingBox2D limits
+mas_perception_msgs/BoundingBox2D limits
 
 ########################
 # Plane name
@@ -22,5 +22,5 @@ string name
 
 ########################
 # Objects associated with plane
-mcr_perception_msgs/ObjectList object_list
+mas_perception_msgs/ObjectList object_list
 

--- a/msg/PlaneList.msg
+++ b/msg/PlaneList.msg
@@ -1,2 +1,2 @@
 # A list of planes
-mcr_perception_msgs/Plane[] planes
+mas_perception_msgs/Plane[] planes

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package>
-  <name>mcr_perception_msgs</name>
+  <name>mas_perception_msgs</name>
   <version>0.0.1</version>
   <description>common perception messages</description>
 

--- a/ros/launch/object_msg_visualizer.launch
+++ b/ros/launch/object_msg_visualizer.launch
@@ -5,7 +5,7 @@
   
   <group ns="mcr_perception">
   
-    <node pkg="mcr_perception_msgs" type="object_msg_visualizer_node" name="object_msg_visualizer" output="screen">
+    <node pkg="mas_perception_msgs" type="object_msg_visualizer_node" name="object_msg_visualizer" output="screen">
       <remap from="~input/object" to="$(arg input_object_topic)" />
       <remap from="~visualization_marker_array" to="/visualization_marker_array" />
     </node>

--- a/ros/src/object_msg_visualizer_node.cpp
+++ b/ros/src/object_msg_visualizer_node.cpp
@@ -5,7 +5,7 @@
  *      Author: Frederik Hegger
  */
 
-#include <mcr_perception_msgs/Object.h>
+#include <mas_perception_msgs/Object.h>
 #include <ros/ros.h>
 #include <visualization_msgs/MarkerArray.h>
 
@@ -26,7 +26,7 @@ public:
         pub_marker_.shutdown();
     }
 
-    void objectCallback(const mcr_perception_msgs::Object::Ptr msg)
+    void objectCallback(const mas_perception_msgs::Object::Ptr msg)
     {
         visualization_msgs::MarkerArray  marker_array;
         visualization_msgs::Marker marker_text;

--- a/srv/GetObjectList.srv
+++ b/srv/GetObjectList.srv
@@ -3,4 +3,4 @@
 time stamp
 
 # List of all recorded objects
-mcr_perception_msgs/Object[] objects
+mas_perception_msgs/Object[] objects

--- a/srv/GetPersonList.srv
+++ b/srv/GetPersonList.srv
@@ -1,2 +1,2 @@
 ---
-mcr_perception_msgs/PersonList person_list			# list of found persons
+mas_perception_msgs/PersonList person_list			# list of found persons


### PR DESCRIPTION
This commit removes the old `mcr` prefix and substitutes it with a more
general `mas` prefix