### PR TITLE
Add RegionOfInterest field. Used for 2d bbox proposal

### DIFF
--- a/msg/Object.msg
+++ b/msg/Object.msg
@@ -23,7 +23,7 @@ sensor_msgs/Image rgb_image
 sensor_msgs/PointCloud2 pointcloud
 
 # The bounding box of the object
-mcr_perception_msgs/BoundingBox bounding_box
+mas_perception_msgs/BoundingBox bounding_box
 
 # The ROI of image (2D BBox)
 sensor_msgs/RegionOfInterest roi

--- a/msg/Object.msg
+++ b/msg/Object.msg
@@ -23,5 +23,7 @@ sensor_msgs/Image rgb_image
 sensor_msgs/PointCloud2 pointcloud
 
 # The bounding box of the object
-mas_perception_msgs/BoundingBox bounding_box
+mcr_perception_msgs/BoundingBox bounding_box
 
+# The ROI of image (2D BBox)
+sensor_msgs/RegionOfInterest roi


### PR DESCRIPTION
* Add: sensor_msgs/RegionOfInterest.msg in Object.msg
* It contains 2d bbox proposal information (x_offset, y_offset, width, height)