### PR TITLE
Detect objects action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED
 add_action_files(DIRECTORY action
   FILES
     DetectScene.action
+    DetectObjects.action
 )
 
 add_message_files(

--- a/action/DetectObjects.action
+++ b/action/DetectObjects.action
@@ -1,0 +1,6 @@
+# Empty Goal
+---
+# Result
+mas_perception_msgs/ObjectList objects
+---
+# Empty Feedback


### PR DESCRIPTION
This PR adds a definition of an action for detecting objects in a scene. Unlike the `DetectScene` action, the new `DetectObjects` action can be used for perceiving a scene without plane fitting (which is useful for general environment exploration as well as perception that is not about tabletop manipulation).