### PR TITLE
[noetic] Increase min catkin requirement to minimize warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mas_perception_msgs)
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
Minimum catkin version required in noetic [to minimize warning](http://wiki.ros.org/noetic/Migration)

Related: [at work migration to noetic](https://github.com/orgs/b-it-bots/projects/16)