### PR TITLE
Add image field to DetectObjects action message

### DIFF
--- a/action/DetectObjects.action
+++ b/action/DetectObjects.action
@@ -2,5 +2,6 @@
 ---
 # Result
 mas_perception_msgs/ObjectList objects
+sensor_msgs/Image image
 ---
 # Empty Feedback


### PR DESCRIPTION
This PR extends the `DetectionObjects` action message to include an additional field `image` of type `sensor_msgs/Image`, which contains the full RGB image used in the detection phase.